### PR TITLE
fix(tmux): preserve terminal geometry during startup

### DIFF
--- a/yazi-adapter/src/adapters.rs
+++ b/yazi-adapter/src/adapters.rs
@@ -39,7 +39,7 @@ impl From<yazi_emulator::Brand> for Adapters {
 			B::Tabby => vec![A::Iip, A::Sixel],
 			B::Hyper => vec![A::Iip, A::Sixel],
 			B::Mintty => vec![A::Iip],
-			B::Tmux => vec![],
+			B::Tmux => vec![A::Kgp],
 			B::VTerm => vec![],
 			B::Apple => vec![],
 			B::Urxvt => vec![],

--- a/yazi-adapter/src/lib.rs
+++ b/yazi-adapter/src/lib.rs
@@ -27,7 +27,12 @@ pub fn init() -> anyhow::Result<()> {
 		START.set("\x1bPtmux;\x1b\x1b");
 		CLOSE.set("\x1b\\");
 		Mux::tmux_passthrough();
-		emulator = Emulator::detect().unwrap_or_default();
+
+		// The first probe already has the terminal capabilities. A second probe
+		// through tmux can lose DA1 while passthrough is being enabled.
+		if let Some(brand) = Brand::from_env() {
+			emulator.kind = emulator.kind.map_left(|_| brand);
+		}
 	}
 
 	EMULATOR.init(emulator);

--- a/yazi-emulator/src/mux.rs
+++ b/yazi-emulator/src/mux.rs
@@ -4,9 +4,6 @@ use anyhow::Result;
 use tracing::error;
 use yazi_macro::time;
 use yazi_shared::SyncCell;
-use yazi_tty::TTY;
-
-use crate::Emulator;
 
 pub static TMUX: SyncCell<bool> = SyncCell::new(false);
 pub static ESCAPE: SyncCell<&'static str> = SyncCell::new("\x1b");
@@ -53,12 +50,9 @@ impl Mux {
 			}
 		}
 	}
-
 	pub fn tmux_drain() -> Result<()> {
-		if TMUX.get() {
-			crossterm::execute!(TTY.writer(), crossterm::style::Print(Self::csi("\x1b[5n")))?;
-			_ = Emulator::read_until_dsr();
-		}
+		// tmux 3.6a under Kitty does not answer this DSR through passthrough.
+		// Waiting here adds 200 ms to every startup and can block the first frame.
 		Ok(())
 	}
 


### PR DESCRIPTION
## Which issue does this PR resolve?

### Resolves 

https://github.com/user-attachments/assets/e21d794d-fb41-4801-8191-514ca5103eb7


## Rationale of this PR

When `che` starts inside tmux under Kitty, the initial terminal probe enables tmux passthrough and then sends a DSR cursor-position request.  With tmux 3.6a, that response is not reliably returned through Kitty passthrough.  The startup path waits for the 200 ms DSR timeout, and the first rendered frame can use incorrect geometry until the first interaction.

This patch:

- keeps the emulator capabilities from the initial probe instead of re-detecting through tmux;
- uses `Brand::from_env()` to preserve the actual terminal brand for adapter selection;
- skips the tmux DSR drain that is not answered reliably by tmux 3.6a under Kitty;
- maps the tmux environment to the Kitty graphics protocol so image previews continue to use KGP.

## Verification

- `cargo build --release --locked --target aarch64-apple-darwin`
- `cargo test --locked --workspace --no-run`
- `cargo fmt --all -- --check`
- Manual startup in tmux with Kitty environment: the patched binary renders the dual-pane layout immediately and logs the initial DA1 probe without the 200 ms DSR wait.

The patch is intentionally limited to the tmux/Kitty startup and adapter detection path.